### PR TITLE
Removed the -listen parameter

### DIFF
--- a/src/content/mining-win-nvidia.md
+++ b/src/content/mining-win-nvidia.md
@@ -28,7 +28,7 @@ Download this special [Pool Miner](https://github.com/tpruvot/ccminer/releases) 
 Now you will want to create a new text file and rename it to `Run-Miner-Pool-Nvidia.bat` (**Make sure the file ends with .bat**).  
 Edit the file (Right Click > Edit), and enter this 
 ```
-ccminer-x64 --algo=scrypt:11 -o POOL -u ADDRESS -listen
+ccminer-x64 --algo=scrypt:11 -o POOL -u ADDRESS
 pause
 ```  
 Then, replace the `POOL` to the pool's address (you can find some available pools [here](pool-mining.html#test-net)).  


### PR DESCRIPTION
Removed the -listen parameter as ccminer argument, for poolmining, which seems to be useless and incorrect.
( generate the following error when used : "GPU #0: Given launch config 'isten' does not validate." , and isn't in the parameter list of ccminer  -h )