### PR TITLE
Update getinfo with getblockchaininfo and reword

### DIFF
--- a/src/content/wallet-nix.md
+++ b/src/content/wallet-nix.md
@@ -28,9 +28,8 @@ Now repeat **Step 2**, you should be good to go.
 
 ## Step 5. Download the Blockchain
 While keeping your network terminal open, open a new terminal.  
-Navigate to your Garlicoin folder and type `./garlicoin-cli getinfo`.  
-Keep using that command until the number of blocks stops changing.  
-If it stops changing (after you run the command a bunch of times), it means that you have downloaded all of the blockchain and can now move to the next step.
+Navigate to your Garlicoin folder and type `./garlicoin-cli getblockchaininfo`.  
+This command displays information about the blockchain you have downloaded, the `blocks` value at the top is the number of blocks that has been recieved. You can run this command a few times to check the status once it hits the value (https://explorer.grlc-bakery.fun/api/getblockcount)[here] your blockchain sync is complete.
 
 # Getting a Wallet
 Once you have gotten the Network up and running, you will need to get a wallet address.  

--- a/src/content/wallet-nix.md
+++ b/src/content/wallet-nix.md
@@ -29,7 +29,7 @@ Now repeat **Step 2**, you should be good to go.
 ## Step 5. Download the Blockchain
 While keeping your network terminal open, open a new terminal.  
 Navigate to your Garlicoin folder and type `./garlicoin-cli getblockchaininfo`.  
-This command displays information about the blockchain you have downloaded, the `blocks` value at the top is the number of blocks that has been recieved. You can run this command a few times to check the status once it hits the value (https://explorer.grlc-bakery.fun/api/getblockcount)[here] your blockchain sync is complete.
+This command displays information about the blockchain you have downloaded, the `blocks` value at the top is the number of blocks that has been recieved. You can run this command a few times to check the status. Once it hits the value (https://explorer.grlc-bakery.fun/api/getblockcount)[here] your blockchain sync is complete.
 
 # Getting a Wallet
 Once you have gotten the Network up and running, you will need to get a wallet address.  

--- a/src/content/wallet-win.md
+++ b/src/content/wallet-win.md
@@ -46,9 +46,8 @@ Now repeat **Step 2**, you should be good to go.
 
 ## Step 5. Download the Blockchain
 While keeping your network window open, Open a new Command Prompt.  
-Navigate to your Garlicoin folder (use `cd C:\Garlic\`), and type `garlicoin-cli getinfo`.  
-Keep using that command until the number of blocks stops changing.  
-If it stops changing (after you run the command a bunch of times), it means that you have downloaded all of the blockchain and can now move to the next step.
+Navigate to your Garlicoin folder (use `cd C:\Garlic\`), and type `garlicoin-cli getblockchaininfo`.  
+This command displays information about the blockchain you have downloaded, the `blocks` value at the top is the number of blocks that has been recieved. You can run this command a few times to check the status once it hits the value (https://explorer.grlc-bakery.fun/api/getblockcount)[here] your blockchain sync is complete.
 
 # Getting a Wallet
 Once you have gotten the Network up and running, you will need to get a wallet address.  

--- a/src/content/wallet-win.md
+++ b/src/content/wallet-win.md
@@ -47,7 +47,7 @@ Now repeat **Step 2**, you should be good to go.
 ## Step 5. Download the Blockchain
 While keeping your network window open, Open a new Command Prompt.  
 Navigate to your Garlicoin folder (use `cd C:\Garlic\`), and type `garlicoin-cli getblockchaininfo`.  
-This command displays information about the blockchain you have downloaded, the `blocks` value at the top is the number of blocks that has been recieved. You can run this command a few times to check the status once it hits the value (https://explorer.grlc-bakery.fun/api/getblockcount)[here] your blockchain sync is complete.
+This command displays information about the blockchain you have downloaded, the `blocks` value at the top is the number of blocks that has been recieved. You can run this command a few times to check the statu. Once it hits the value (https://explorer.grlc-bakery.fun/api/getblockcount)[here] your blockchain sync is complete.
 
 # Getting a Wallet
 Once you have gotten the Network up and running, you will need to get a wallet address.  


### PR DESCRIPTION
Some people were getting confused with the wording thinking running `getinfo`
is actually updating the blockchain, hopefully this is worded a bit better now.

Seeing as `getinfo` is deprecated this has been replaced with the correct command
`getblockchaininfo`.

Translations needed.