### PR TITLE
Fix troubleshooting for spamming 0kH/s and no CUDA-capable devices found

### DIFF
--- a/src/content/mining-win-nvidia.md
+++ b/src/content/mining-win-nvidia.md
@@ -79,10 +79,11 @@ Disabling DSR factors in nvidia control panel should fix the error.
 
 ## Spamming 0 kH/s
 - Disabling DSR factors in nvidia control panel should fix the error.
-- If that doesn't work and you have an **old GPU** (under 900 series), try using [this miner](https://github.com/KBomba/ccminer-KBomba/releases/tag/V1.0.02) instead. 
+- If that doesn't work and you have an **old GPU** (only supports Compute Capability 2.1 or lower), try using [this miner](https://github.com/tpruvot/ccminer/releases/tag/v2.2-tpruvot) instead. 
 
 ## no CUDA-capable device detected
-Make sure that you have updated your Nvidia Drivers and that your Graphics Card can be found in [this list](https://developer.nvidia.com/cuda-gpus) (minimum required is `Compute 5.0`).
+- Make sure that you have updated your Nvidia Drivers and that your Graphics Card can be found in [this list](https://developer.nvidia.com/cuda-gpus) (minimum Compute Capability is 3.0).
+- If your Graphics Card's Compute Capability is 2.1 or lower, try using [this miner](https://github.com/tpruvot/ccminer/releases/tag/v2.2-tpruvot).
 
 ## Access is denied
 Check your antivirus, it might be preventing the network from functioning


### PR DESCRIPTION
* Clarify that old cards means cards with Compute Capability <= 2.1 because ccminer 2.2.4 supports CC >= 3.0
* Switch from ccminer-KBomba to tpruvot's ccminer 2.2 (which should support CC <= 2.1)