### PR TITLE
Update .gitignore to exclude yarn lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock
 
 # Runtime data
 pids


### PR DESCRIPTION
As you are using npm and not yarn, this might make sense to not mix them up for other users.